### PR TITLE
ci: Update golangci-lint config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -157,11 +157,11 @@ issues:
   max-same-issues: 0
   new: false
   fix: false
+  uniq-by-line: false
 output:
   formats:
     - format: tab
   print-issued-lines: false
   print-linter-name: true
-  uniq-by-line: false
   path-prefix: ""
   sort-results: true


### PR DESCRIPTION
uniq-by-line directive has moved from `output` to `issues`.